### PR TITLE
OFL.txt : fix project URL

### DIFF
--- a/OFL.txt
+++ b/OFL.txt
@@ -1,4 +1,4 @@
-Copyright 2020 The Rampart Project Authors (https://github.com/fontworks-fonts/Reggae)
+Copyright 2020 The Rampart Project Authors (https://github.com/fontworks-fonts/Rampart)
 
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:


### PR DESCRIPTION
Fixed the copyright project URL in the top of the OFL.txt.
オープンフォントライセンス OFL.txt の1行目にあるプロジェクトURLが食い違っていたため，修正を提案します．